### PR TITLE
Adiciona endpoint de inicia-preparo

### DIFF
--- a/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/IniciaPreparoPedidoController.java
+++ b/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/IniciaPreparoPedidoController.java
@@ -8,9 +8,11 @@ import com.fiap.mspedidoapi.domain.output.pedido.PedidoProntoOutput;
 import com.fiap.mspedidoapi.domain.presenters.pedido.PedidoProntoPresenter;
 import com.fiap.mspedidoapi.domain.useCase.pedido.IniciaPreparoPedidoUseCase;
 import com.fiap.mspedidoapi.infra.adpter.repository.pedido.PreparaPedidoRepository;
+import com.fiap.mspedidoapi.infra.kafka.producers.PreparaPedidoProducer;
 import com.fiap.mspedidoapi.infra.repository.PedidosMongoRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -22,11 +24,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("cozinha/pedido")
 public class IniciaPreparoPedidoController {
     private final PedidosMongoRepository pedidosMongoRepository;
+    @Value("${spring.kafka.producer.bootstrap-servers}")
+    private String servers;
 
     @PostMapping("/inicia-preparo")
     @Operation(tags = {"cozinha"})
     public ResponseEntity<Object> iniciaPreparoPedido(@RequestBody StoreIniciaPreparoProdutoRequest iniciaPreparoProdutoRequest) {
-        IniciaPreparoPedidoUseCase useCase = new IniciaPreparoPedidoUseCase(new PreparaPedidoRepository(pedidosMongoRepository));
+        IniciaPreparoPedidoUseCase useCase = new IniciaPreparoPedidoUseCase(
+            new PreparaPedidoRepository(pedidosMongoRepository),
+            new PreparaPedidoProducer(servers));
         useCase.execute(iniciaPreparoProdutoRequest.uuid(), iniciaPreparoProdutoRequest.tempoDePreparo());
         OutputInterface outputInterface = useCase.getOutputInterface();
 

--- a/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/IniciaPreparoPedidoController.java
+++ b/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/IniciaPreparoPedidoController.java
@@ -7,7 +7,7 @@ import com.fiap.mspedidoapi.domain.generic.output.OutputInterface;
 import com.fiap.mspedidoapi.domain.output.pedido.PedidoProntoOutput;
 import com.fiap.mspedidoapi.domain.presenters.pedido.PedidoProntoPresenter;
 import com.fiap.mspedidoapi.domain.useCase.pedido.IniciaPreparoPedidoUseCase;
-import com.fiap.mspedidoapi.infra.adpter.repository.pedido.BuscarListaPedidoRepository;
+import com.fiap.mspedidoapi.infra.adpter.repository.pedido.PreparaPedidoRepository;
 import com.fiap.mspedidoapi.infra.repository.PedidosMongoRepository;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class IniciaPreparoPedidoController {
     @PostMapping("/inicia-preparo")
     @Operation(tags = {"cozinha"})
     public ResponseEntity<Object> iniciaPreparoPedido(@RequestBody StoreIniciaPreparoProdutoRequest iniciaPreparoProdutoRequest) {
-        IniciaPreparoPedidoUseCase useCase = new IniciaPreparoPedidoUseCase(new BuscarListaPedidoRepository(pedidosMongoRepository));
+        IniciaPreparoPedidoUseCase useCase = new IniciaPreparoPedidoUseCase(new PreparaPedidoRepository(pedidosMongoRepository));
         useCase.execute(iniciaPreparoProdutoRequest.uuid(), iniciaPreparoProdutoRequest.tempoDePreparo());
         OutputInterface outputInterface = useCase.getOutputInterface();
 

--- a/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/IniciaPreparoPedidoController.java
+++ b/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/IniciaPreparoPedidoController.java
@@ -1,0 +1,40 @@
+package com.fiap.mspedidoapi.application.controllers.cozinha.pedidos.preparo;
+
+import com.fiap.mspedidoapi.application.controllers.cozinha.pedidos.preparo.requests.StoreIniciaPreparoProdutoRequest;
+import com.fiap.mspedidoapi.application.response.GenericResponse;
+import com.fiap.mspedidoapi.application.response.PresenterResponse;
+import com.fiap.mspedidoapi.domain.generic.output.OutputInterface;
+import com.fiap.mspedidoapi.domain.output.pedido.PedidoProntoOutput;
+import com.fiap.mspedidoapi.domain.presenters.pedido.PedidoProntoPresenter;
+import com.fiap.mspedidoapi.domain.useCase.pedido.IniciaPreparoPedidoUseCase;
+import com.fiap.mspedidoapi.infra.adpter.repository.pedido.BuscarListaPedidoRepository;
+import com.fiap.mspedidoapi.infra.repository.PedidosMongoRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("cozinha/pedido")
+public class IniciaPreparoPedidoController {
+    private final PedidosMongoRepository pedidosMongoRepository;
+
+    @PostMapping("/inicia-preparo")
+    @Operation(tags = {"cozinha"})
+    public ResponseEntity<Object> iniciaPreparoPedido(@RequestBody StoreIniciaPreparoProdutoRequest iniciaPreparoProdutoRequest) {
+        IniciaPreparoPedidoUseCase useCase = new IniciaPreparoPedidoUseCase(new BuscarListaPedidoRepository(pedidosMongoRepository));
+        useCase.execute(iniciaPreparoProdutoRequest.uuid(), iniciaPreparoProdutoRequest.tempoDePreparo());
+        OutputInterface outputInterface = useCase.getOutputInterface();
+
+        if (outputInterface.getOutputStatus().getCode() != 200) {
+            return new GenericResponse().response(outputInterface);
+        }
+
+        PedidoProntoPresenter presenter = new PedidoProntoPresenter((PedidoProntoOutput) outputInterface);
+        return new PresenterResponse().response(presenter);
+    }
+}

--- a/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/requests/StoreIniciaPreparoProdutoRequest.java
+++ b/src/main/java/com/fiap/mspedidoapi/application/controllers/cozinha/pedidos/preparo/requests/StoreIniciaPreparoProdutoRequest.java
@@ -1,0 +1,8 @@
+package com.fiap.mspedidoapi.application.controllers.cozinha.pedidos.preparo.requests;
+
+import java.util.UUID;
+
+public record StoreIniciaPreparoProdutoRequest(
+        UUID uuid,
+        Integer tempoDePreparo
+){}

--- a/src/main/java/com/fiap/mspedidoapi/domain/entity/pedido/PedidoEntity.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/entity/pedido/PedidoEntity.java
@@ -23,6 +23,7 @@ public class PedidoEntity {
     @Enumerated(EnumType.STRING)
     private StatusPagamento statusPagamento;
     private List<ProdutoEntity> produtos;
+    private Integer tempoDePreparoEmMinutos;
     private Float total;
 
     public PedidoEntity(UUID clienteUuid) {
@@ -30,12 +31,13 @@ public class PedidoEntity {
         this.produtos = new ArrayList<>();
     }
 
-    public PedidoEntity(UUID pedidoId, UUID clienteId, StatusPedido statusPedido, StatusPagamento statusPagamento, Float valorTotal) {
+    public PedidoEntity(UUID pedidoId, UUID clienteId, StatusPedido statusPedido, StatusPagamento statusPagamento, Integer tempoDePreparoEmMinutos, Float valorTotal) {
         this.pedidoId = pedidoId;
         this.clienteUuid = clienteId;
         this.statusPedido = statusPedido;
         this.statusPagamento = statusPagamento;
         this.total = valorTotal;
+        this.tempoDePreparoEmMinutos = tempoDePreparoEmMinutos;
         this.produtos = new ArrayList<>();
     }
 

--- a/src/main/java/com/fiap/mspedidoapi/domain/exception/pedido/PedidoNaoEncontradoException.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/exception/pedido/PedidoNaoEncontradoException.java
@@ -1,0 +1,7 @@
+package com.fiap.mspedidoapi.domain.exception.pedido;
+
+public class PedidoNaoEncontradoException extends Exception {
+    public PedidoNaoEncontradoException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/AtualizaPedidoInterface.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/AtualizaPedidoInterface.java
@@ -1,0 +1,9 @@
+package com.fiap.mspedidoapi.domain.gateway.pedido;
+
+import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
+
+import java.util.UUID;
+
+public interface AtualizaPedidoInterface {
+    Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos);
+}

--- a/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/AtualizaPedidoInterface.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/AtualizaPedidoInterface.java
@@ -1,9 +1,0 @@
-package com.fiap.mspedidoapi.domain.gateway.pedido;
-
-import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
-
-import java.util.UUID;
-
-public interface AtualizaPedidoInterface {
-    Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos);
-}

--- a/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/BuscaListaPedidoInterface.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/BuscaListaPedidoInterface.java
@@ -1,9 +1,15 @@
 package com.fiap.mspedidoapi.domain.gateway.pedido;
 
+import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
 import com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity;
+import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
+import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
 
 import java.util.List;
+import java.util.UUID;
 
 public interface BuscaListaPedidoInterface {
+    Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException;
+    Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException;
     List<PedidoEntity> findListaPedidos();
 }

--- a/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/BuscaListaPedidoInterface.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/BuscaListaPedidoInterface.java
@@ -1,15 +1,9 @@
 package com.fiap.mspedidoapi.domain.gateway.pedido;
 
-import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
 import com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity;
-import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
-import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
 
 import java.util.List;
-import java.util.UUID;
 
 public interface BuscaListaPedidoInterface {
-    Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException;
-    Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException;
     List<PedidoEntity> findListaPedidos();
 }

--- a/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/PreparaPedidoInterface.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/PreparaPedidoInterface.java
@@ -1,12 +1,11 @@
 package com.fiap.mspedidoapi.domain.gateway.pedido;
 
-import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
+import com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity;
 import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
-import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
 
 import java.util.UUID;
 
 public interface PreparaPedidoInterface {
-    Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException;
-    Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException;
+    PedidoEntity encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException;
+    PedidoEntity movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException;
 }

--- a/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/PreparaPedidoInterface.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/gateway/pedido/PreparaPedidoInterface.java
@@ -1,0 +1,12 @@
+package com.fiap.mspedidoapi.domain.gateway.pedido;
+
+import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
+import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
+import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
+
+import java.util.UUID;
+
+public interface PreparaPedidoInterface {
+    Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException;
+    Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException;
+}

--- a/src/main/java/com/fiap/mspedidoapi/domain/gateway/producers/PreparaPedidoProducerInterface.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/gateway/producers/PreparaPedidoProducerInterface.java
@@ -1,0 +1,7 @@
+package com.fiap.mspedidoapi.domain.gateway.producers;
+
+import com.fiap.mspedidoapi.domain.output.pedido.PedidoEmPreparacaoOutput;
+
+public interface PreparaPedidoProducerInterface {
+    void send(PedidoEmPreparacaoOutput pedidoEmPreparacaoOutput);
+}

--- a/src/main/java/com/fiap/mspedidoapi/domain/output/pedido/PedidoEmPreparacaoOutput.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/output/pedido/PedidoEmPreparacaoOutput.java
@@ -1,0 +1,34 @@
+package com.fiap.mspedidoapi.domain.output.pedido;
+
+import com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity;
+import com.fiap.mspedidoapi.domain.generic.output.OutputInterface;
+import com.fiap.mspedidoapi.domain.generic.output.OutputStatus;
+import lombok.Data;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+@Data
+@RequiredArgsConstructor
+@Getter
+@Setter
+public class PedidoEmPreparacaoOutput implements OutputInterface {
+    private PedidoEntity pedido;
+    private OutputStatus outputStatus;
+
+    public PedidoEmPreparacaoOutput(PedidoEntity pedido, OutputStatus outputStatus) {
+        this.pedido = pedido;
+        this.outputStatus = outputStatus;
+    }
+
+    @Override
+    public Object getBody() {
+        return this.pedido;
+    }
+
+    @Override
+    public OutputStatus getOutputStatus() {
+        return this.outputStatus;
+    }
+    
+}

--- a/src/main/java/com/fiap/mspedidoapi/domain/useCase/pedido/IniciaPreparoPedidoUseCase.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/useCase/pedido/IniciaPreparoPedidoUseCase.java
@@ -3,7 +3,7 @@ package com.fiap.mspedidoapi.domain.useCase.pedido;
 import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
 import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
 import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
-import com.fiap.mspedidoapi.domain.gateway.pedido.BuscaListaPedidoInterface;
+import com.fiap.mspedidoapi.domain.gateway.pedido.PreparaPedidoInterface;
 import com.fiap.mspedidoapi.domain.generic.output.OutputError;
 import com.fiap.mspedidoapi.domain.generic.output.OutputInterface;
 import com.fiap.mspedidoapi.domain.generic.output.OutputStatus;
@@ -18,30 +18,40 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class IniciaPreparoPedidoUseCase {
     
-    private final BuscaListaPedidoInterface buscaListaPedidoInterface;
+    private final PreparaPedidoInterface preparaPedidoInterface;
     private OutputInterface outputInterface;
 
     public void execute(UUID pedidoUUID, Integer tempoDePreparoEmMinutos) {
         try {
-            Pedido pedidoEncontrado = buscaListaPedidoInterface.encontraPedidoPorUuid(pedidoUUID);
-        
-            if(pedidoEncontrado.getStatusPedido() != StatusPedido.RECEBIDO) {
-                this.outputInterface = new PedidoProntoOutput(
-                        null,
-                        new OutputStatus(404, "Not found", "Pedido precisa estar com status RECEBIDO para dar inicio ao preparo")
+
+            if(tempoDePreparoEmMinutos <= 0){
+                this.outputInterface = new OutputError(
+                    "Error", 
+                    new OutputStatus(404, "Falha", "Tempo de preparo precisa ser positivo")
                 );
                 return;
             }
 
-            Entrega entrega = buscaListaPedidoInterface.movePedidoParaEmPreparacao(pedidoUUID, tempoDePreparoEmMinutos);
+            Pedido pedidoEncontrado = preparaPedidoInterface.encontraPedidoPorUuid(pedidoUUID);
+
+            if(pedidoEncontrado.getStatusPedido() != StatusPedido.RECEBIDO) {
+                this.outputInterface = new OutputError(
+                    "Error", 
+                    new OutputStatus(404, "Not found", "Pedido precisa estar com status RECEBIDO para dar inicio ao preparo")
+                );
+                return;
+            }
+
+            Entrega entrega = preparaPedidoInterface.movePedidoParaEmPreparacao(pedidoUUID, tempoDePreparoEmMinutos);
             this.outputInterface = new PedidoProntoOutput(
                 entrega,
                 new OutputStatus(200, "OK", "Pedido atualizado.")
             );
 
         }catch (PedidoNaoEncontradoException e) {
-            this.outputInterface = new PedidoProntoOutput(
-                    null,
+            System.out.println("Pedido nao enconstrado");
+            this.outputInterface = new OutputError(
+                    e.getMessage(),
                     new OutputStatus(404, "Not found", "Pedido não encontrado")
             );
         } catch (Exception e) {

--- a/src/main/java/com/fiap/mspedidoapi/domain/useCase/pedido/IniciaPreparoPedidoUseCase.java
+++ b/src/main/java/com/fiap/mspedidoapi/domain/useCase/pedido/IniciaPreparoPedidoUseCase.java
@@ -1,0 +1,55 @@
+package com.fiap.mspedidoapi.domain.useCase.pedido;
+
+import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
+import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
+import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
+import com.fiap.mspedidoapi.domain.gateway.pedido.BuscaListaPedidoInterface;
+import com.fiap.mspedidoapi.domain.generic.output.OutputError;
+import com.fiap.mspedidoapi.domain.generic.output.OutputInterface;
+import com.fiap.mspedidoapi.domain.generic.output.OutputStatus;
+import com.fiap.mspedidoapi.domain.output.pedido.PedidoProntoOutput;
+import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.UUID;
+
+@Getter
+@RequiredArgsConstructor
+public class IniciaPreparoPedidoUseCase {
+    
+    private final BuscaListaPedidoInterface buscaListaPedidoInterface;
+    private OutputInterface outputInterface;
+
+    public void execute(UUID pedidoUUID, Integer tempoDePreparoEmMinutos) {
+        try {
+            Pedido pedidoEncontrado = buscaListaPedidoInterface.encontraPedidoPorUuid(pedidoUUID);
+        
+            if(pedidoEncontrado.getStatusPedido() != StatusPedido.RECEBIDO) {
+                this.outputInterface = new PedidoProntoOutput(
+                        null,
+                        new OutputStatus(404, "Not found", "Pedido precisa estar com status RECEBIDO para dar inicio ao preparo")
+                );
+                return;
+            }
+
+            Entrega entrega = buscaListaPedidoInterface.movePedidoParaEmPreparacao(pedidoUUID, tempoDePreparoEmMinutos);
+            this.outputInterface = new PedidoProntoOutput(
+                entrega,
+                new OutputStatus(200, "OK", "Pedido atualizado.")
+            );
+
+        }catch (PedidoNaoEncontradoException e) {
+            this.outputInterface = new PedidoProntoOutput(
+                    null,
+                    new OutputStatus(404, "Not found", "Pedido não encontrado")
+            );
+        } catch (Exception e) {
+            outputInterface = new OutputError(
+                    e.getMessage(),
+                    new OutputStatus(500, "Internal Server Error", "Erro no servidor")
+            );
+        }
+    }
+    
+}

--- a/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/BuscarListaPedidoRepository.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/BuscarListaPedidoRepository.java
@@ -1,48 +1,18 @@
 package com.fiap.mspedidoapi.infra.adpter.repository.pedido;
 
-import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
 import com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity;
 import com.fiap.mspedidoapi.domain.entity.pedido.ProdutoEntity;
-import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
-import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
 import com.fiap.mspedidoapi.domain.gateway.pedido.BuscaListaPedidoInterface;
-import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
 import com.fiap.mspedidoapi.infra.collection.pedido.items.Produto;
 import com.fiap.mspedidoapi.infra.repository.PedidosMongoRepository;
 import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-import java.util.UUID;
 
 @RequiredArgsConstructor
 public class BuscarListaPedidoRepository implements BuscaListaPedidoInterface {
     public final PedidosMongoRepository pedidosMongoRepository;
-
-    @Override
-    public Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException {
-        Optional<Pedido> pedidoEncontrado = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
-        if(pedidoEncontrado.isPresent()){
-            return pedidoEncontrado.get();
-        }else{
-            throw new PedidoNaoEncontradoException("Pedido não encontrado");
-        }
-    }
-    
-    @Override
-    public Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException {
-        Optional<Pedido> pedido = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
-        if(pedido.isPresent()){
-            Pedido pedidoEncontrado = pedido.get();
-            pedidoEncontrado.setTempoDePreparo(tempoDePreparoEmMinutos);
-            pedidoEncontrado.setStatusPedido(StatusPedido.EM_PREPARACAO);
-            pedidosMongoRepository.save(pedidoEncontrado);
-            return new Entrega(pedidoEncontrado.getUuidPedido(), pedidoEncontrado.getNumeroPedido(), pedidoEncontrado.getStatusPedido());
-        }else{
-            throw new PedidoNaoEncontradoException("Pedido não encontrado");
-        }
-    }
 
     private static List<ProdutoEntity> getProdutoEntities(List<Produto>  produtosDoPedido) {
         List<ProdutoEntity> produtosList = new ArrayList<>();

--- a/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/BuscarListaPedidoRepository.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/BuscarListaPedidoRepository.java
@@ -1,7 +1,10 @@
 package com.fiap.mspedidoapi.infra.adpter.repository.pedido;
 
+import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
 import com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity;
 import com.fiap.mspedidoapi.domain.entity.pedido.ProdutoEntity;
+import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
+import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
 import com.fiap.mspedidoapi.domain.gateway.pedido.BuscaListaPedidoInterface;
 import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
 import com.fiap.mspedidoapi.infra.collection.pedido.items.Produto;
@@ -10,10 +13,36 @@ import lombok.RequiredArgsConstructor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 @RequiredArgsConstructor
 public class BuscarListaPedidoRepository implements BuscaListaPedidoInterface {
     public final PedidosMongoRepository pedidosMongoRepository;
+
+    @Override
+    public Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException {
+        Optional<Pedido> pedidoEncontrado = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
+        if(pedidoEncontrado.isPresent()){
+            return pedidoEncontrado.get();
+        }else{
+            throw new PedidoNaoEncontradoException("Pedido não encontrado");
+        }
+    }
+    
+    @Override
+    public Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException {
+        Optional<Pedido> pedido = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
+        if(pedido.isPresent()){
+            Pedido pedidoEncontrado = pedido.get();
+            pedidoEncontrado.setTempoDePreparo(tempoDePreparoEmMinutos);
+            pedidoEncontrado.setStatusPedido(StatusPedido.EM_PREPARACAO);
+            pedidosMongoRepository.save(pedidoEncontrado);
+            return new Entrega(pedidoEncontrado.getUuidPedido(), pedidoEncontrado.getNumeroPedido(), pedidoEncontrado.getStatusPedido());
+        }else{
+            throw new PedidoNaoEncontradoException("Pedido não encontrado");
+        }
+    }
 
     private static List<ProdutoEntity> getProdutoEntities(List<Produto>  produtosDoPedido) {
         List<ProdutoEntity> produtosList = new ArrayList<>();
@@ -41,6 +70,7 @@ public class BuscarListaPedidoRepository implements BuscaListaPedidoInterface {
                     pedidoCollection.getClienteUuid(),
                     pedidoCollection.getStatusPedido(),
                     pedidoCollection.getStatusPagamento(),
+                    pedidoCollection.getTempoDePreparo(),
                     pedidoCollection.getTotal()
             );
 

--- a/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/PreparaPedidoRepository.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/PreparaPedidoRepository.java
@@ -1,6 +1,5 @@
 package com.fiap.mspedidoapi.infra.adpter.repository.pedido;
 
-import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
 import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
 import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
 import com.fiap.mspedidoapi.domain.gateway.pedido.PreparaPedidoInterface;
@@ -16,24 +15,40 @@ public class PreparaPedidoRepository implements PreparaPedidoInterface{
     public final PedidosMongoRepository pedidosMongoRepository;
     
     @Override
-    public Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException {
+    public com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException {
         Optional<Pedido> pedidoEncontrado = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
         if(pedidoEncontrado.isPresent()){
-            return pedidoEncontrado.get();
+            Pedido pedidoModel = pedidoEncontrado.get();
+            return new com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity(
+                pedidoModel.getUuidPedido(),
+                pedidoModel.getClienteUuid(),
+                pedidoModel.getStatusPedido(),
+                pedidoModel.getStatusPagamento(),
+                pedidoModel.getTempoDePreparo(),
+                pedidoModel.getTotal()
+            );
         }else{
             throw new PedidoNaoEncontradoException("Pedido não encontrado");
         }
     }
     
     @Override
-    public Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException {
+    public com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException {
         Optional<Pedido> pedido = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
         if(pedido.isPresent()){
-            Pedido pedidoEncontrado = pedido.get();
-            pedidoEncontrado.setTempoDePreparo(tempoDePreparoEmMinutos);
-            pedidoEncontrado.setStatusPedido(StatusPedido.EM_PREPARACAO);
-            pedidosMongoRepository.save(pedidoEncontrado);
-            return new Entrega(pedidoEncontrado.getUuidPedido(), pedidoEncontrado.getNumeroPedido(), pedidoEncontrado.getStatusPedido());
+            Pedido pedidoModel = pedido.get();
+            pedidoModel.setTempoDePreparo(tempoDePreparoEmMinutos);
+            pedidoModel.setStatusPedido(StatusPedido.EM_PREPARACAO);
+            pedidosMongoRepository.save(pedidoModel);
+
+            return new com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity(
+                pedidoModel.getUuidPedido(),
+                pedidoModel.getClienteUuid(),
+                pedidoModel.getStatusPedido(),
+                pedidoModel.getStatusPagamento(),
+                pedidoModel.getTempoDePreparo(),
+                pedidoModel.getTotal()
+            );
         }else{
             throw new PedidoNaoEncontradoException("Pedido não encontrado");
         }

--- a/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/PreparaPedidoRepository.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/PreparaPedidoRepository.java
@@ -1,0 +1,41 @@
+package com.fiap.mspedidoapi.infra.adpter.repository.pedido;
+
+import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
+import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
+import com.fiap.mspedidoapi.domain.exception.pedido.PedidoNaoEncontradoException;
+import com.fiap.mspedidoapi.domain.gateway.pedido.PreparaPedidoInterface;
+import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
+import com.fiap.mspedidoapi.infra.repository.PedidosMongoRepository;
+import lombok.RequiredArgsConstructor;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@RequiredArgsConstructor
+public class PreparaPedidoRepository implements PreparaPedidoInterface{
+    public final PedidosMongoRepository pedidosMongoRepository;
+    
+    @Override
+    public Pedido encontraPedidoPorUuid(UUID pedidoUuid) throws PedidoNaoEncontradoException {
+        Optional<Pedido> pedidoEncontrado = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
+        if(pedidoEncontrado.isPresent()){
+            return pedidoEncontrado.get();
+        }else{
+            throw new PedidoNaoEncontradoException("Pedido não encontrado");
+        }
+    }
+    
+    @Override
+    public Entrega movePedidoParaEmPreparacao(UUID pedidoUuid, Integer tempoDePreparoEmMinutos) throws PedidoNaoEncontradoException {
+        Optional<Pedido> pedido = pedidosMongoRepository.findByUuidPedido(pedidoUuid);
+        if(pedido.isPresent()){
+            Pedido pedidoEncontrado = pedido.get();
+            pedidoEncontrado.setTempoDePreparo(tempoDePreparoEmMinutos);
+            pedidoEncontrado.setStatusPedido(StatusPedido.EM_PREPARACAO);
+            pedidosMongoRepository.save(pedidoEncontrado);
+            return new Entrega(pedidoEncontrado.getUuidPedido(), pedidoEncontrado.getNumeroPedido(), pedidoEncontrado.getStatusPedido());
+        }else{
+            throw new PedidoNaoEncontradoException("Pedido não encontrado");
+        }
+    }
+}

--- a/src/main/java/com/fiap/mspedidoapi/infra/collection/pedido/Pedido.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/collection/pedido/Pedido.java
@@ -28,6 +28,8 @@ public class Pedido {
     private StatusPedido statusPedido;
     @Field("status_pagamento")
     private StatusPagamento statusPagamento;
+    @Field("tempo_preparo")
+    private int tempoDePreparo;
     private Float total;
     private List<Produto> produtos;
 }

--- a/src/main/java/com/fiap/mspedidoapi/infra/dependecy/kafka/resolvers/producers/KafkaProducerResolver.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/dependecy/kafka/resolvers/producers/KafkaProducerResolver.java
@@ -7,4 +7,7 @@ public class KafkaProducerResolver {
     public String getEntregaProducer() {
         return KafkaTopicsEnum.entrega.name();
     }
+    public String getPedidoProducer() {
+        return KafkaTopicsEnum.pedido.name();
+    }
 }

--- a/src/main/java/com/fiap/mspedidoapi/infra/kafka/producers/PreparaPedidoProducer.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/kafka/producers/PreparaPedidoProducer.java
@@ -1,0 +1,34 @@
+package com.fiap.mspedidoapi.infra.kafka.producers;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fiap.mspedidoapi.domain.gateway.producers.PreparaPedidoProducerInterface;
+import com.fiap.mspedidoapi.domain.output.pedido.PedidoEmPreparacaoOutput;
+import com.fiap.mspedidoapi.infra.dependecy.kafka.resolvers.producers.KafkaProducerResolver;
+import com.fiap.mspedidoapi.infra.dependecy.kafka.resolvers.producers.KafkaSenderConfig;
+
+import java.util.UUID;
+
+public class PreparaPedidoProducer extends KafkaSenderConfig implements PreparaPedidoProducerInterface {
+    private final ObjectMapper objectMapper = new ObjectMapper();   
+
+    public PreparaPedidoProducer(String servers) {
+        super(servers, new KafkaProducerResolver().getPedidoProducer());
+    }
+
+    @Override
+    public void send(PedidoEmPreparacaoOutput pedidoEmPreparacaoOutput) {
+        try {
+            ObjectNode jsonNode = objectMapper.createObjectNode();
+            jsonNode.put("uuid_pedido", pedidoEmPreparacaoOutput.getPedido().getPedidoId().toString());
+            jsonNode.put("status_pedido", pedidoEmPreparacaoOutput.getPedido().getStatusPedido().toString());
+            jsonNode.put("numero_pedido", pedidoEmPreparacaoOutput.getPedido().getNumeroPedido());
+            jsonNode.put("tempo_preparo", pedidoEmPreparacaoOutput.getPedido().getTempoDePreparoEmMinutos());
+            String json = jsonNode.toString();
+            send(UUID.randomUUID().toString(), json);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+    
+}

--- a/src/main/java/com/fiap/mspedidoapi/infra/repository/PedidosMongoRepository.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/repository/PedidosMongoRepository.java
@@ -8,4 +8,5 @@ import java.util.UUID;
 
 public interface PedidosMongoRepository extends MongoRepository<Pedido, String> {
     Optional<Pedido> findByUuidPedido(UUID uuidPedido);
+    Pedido movePedidoParaEmPreparacao(UUID uuidPedido, Integer tempoDePreparoEmMinutos);
 }

--- a/src/main/java/com/fiap/mspedidoapi/infra/repository/PedidosMongoRepository.java
+++ b/src/main/java/com/fiap/mspedidoapi/infra/repository/PedidosMongoRepository.java
@@ -2,11 +2,13 @@ package com.fiap.mspedidoapi.infra.repository;
 
 import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 import java.util.Optional;
 import java.util.UUID;
 
 public interface PedidosMongoRepository extends MongoRepository<Pedido, String> {
+    
+    @Query("{'uuid_pedido': ?0}")
     Optional<Pedido> findByUuidPedido(UUID uuidPedido);
-    Pedido movePedidoParaEmPreparacao(UUID uuidPedido, Integer tempoDePreparoEmMinutos);
 }

--- a/src/test/java/com/fiap/mspedidoapi/bdd/steps/PedidoProntoRepositorySteps.java
+++ b/src/test/java/com/fiap/mspedidoapi/bdd/steps/PedidoProntoRepositorySteps.java
@@ -2,9 +2,9 @@ package com.fiap.mspedidoapi.bdd.steps;
 
 import com.fiap.mspedidoapi.domain.entity.entrega.Entrega;
 import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
+import com.fiap.mspedidoapi.infra.adpter.repository.pedido.PedidoProntoRepository;
 import com.fiap.mspedidoapi.infra.collection.pedido.Pedido;
 import com.fiap.mspedidoapi.infra.repository.PedidosMongoRepository;
-import com.fiap.mspedidoapi.infra.adpter.repository.pedido.PedidoProntoRepository;
 import io.cucumber.java.Before;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
@@ -17,7 +17,9 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PedidoProntoRepositorySteps {
 

--- a/src/test/java/com/fiap/mspedidoapi/domain/entity/pedido/PedidoEntityTest.java
+++ b/src/test/java/com/fiap/mspedidoapi/domain/entity/pedido/PedidoEntityTest.java
@@ -8,7 +8,10 @@ import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class PedidoEntityTest {
     private PedidoEntity pedidoEntity;
@@ -36,7 +39,7 @@ public class PedidoEntityTest {
         StatusPagamento statusPagamento = StatusPagamento.AGUARDANDO_PAGAMENTO;
         Float total = 100.0f;
 
-        PedidoEntity pedidoEntityFull = new PedidoEntity(pedidoId, clienteId, statusPedido, statusPagamento, total);
+        PedidoEntity pedidoEntityFull = new PedidoEntity(pedidoId, clienteId, statusPedido, statusPagamento, 20, total);
 
         assertNotNull(pedidoEntityFull);
         assertEquals(pedidoId, pedidoEntityFull.getPedidoId());

--- a/src/test/java/com/fiap/mspedidoapi/domain/output/pedido/BuscaTodosPedidoOutputTest.java
+++ b/src/test/java/com/fiap/mspedidoapi/domain/output/pedido/BuscaTodosPedidoOutputTest.java
@@ -18,8 +18,8 @@ public class BuscaTodosPedidoOutputTest {
 
     @BeforeEach
     public void setUp() {
-        PedidoEntity pedido1 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 100.0f);
-        PedidoEntity pedido2 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 200.0f);
+        PedidoEntity pedido1 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 20, 100.0f);
+        PedidoEntity pedido2 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 20, 200.0f);
         pedidos = List.of(pedido1, pedido2);
         outputStatus = new OutputStatus(200, "SUCCESS", "Operação realizada com sucesso");
         buscaTodosPedidoOutput = new BuscaTodosPedidoOutput(pedidos, outputStatus);
@@ -45,7 +45,7 @@ public class BuscaTodosPedidoOutputTest {
 
     @Test
     public void devePermitirAtualizarListPedidos() {
-        PedidoEntity novoPedido = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 300.0f);
+        PedidoEntity novoPedido = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null,20, 300.0f);
         List<PedidoEntity> novosPedidos = List.of(novoPedido);
         buscaTodosPedidoOutput.setListPedidos(novosPedidos);
 
@@ -96,7 +96,7 @@ public class BuscaTodosPedidoOutputTest {
 
     @Test
     public void equalsDeveRetornarFalseParaListPedidosDiferentes() {
-        PedidoEntity pedidoDiferente = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 300.0f);
+        PedidoEntity pedidoDiferente = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 20, 300.0f);
         List<PedidoEntity> pedidosDiferentes = List.of(pedidoDiferente);
         BuscaTodosPedidoOutput outputDiferente = new BuscaTodosPedidoOutput(pedidosDiferentes, outputStatus);
         assertThat(buscaTodosPedidoOutput).isNotEqualTo(outputDiferente);
@@ -144,7 +144,7 @@ public class BuscaTodosPedidoOutputTest {
 
     @Test
     public void hashCodeDeveSerDiferenteParaObjetosDiferentes() {
-        PedidoEntity pedidoDiferente = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 300.0f);
+        PedidoEntity pedidoDiferente = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 20, 300.0f);
         List<PedidoEntity> pedidosDiferentes = List.of(pedidoDiferente);
         BuscaTodosPedidoOutput outputDiferente = new BuscaTodosPedidoOutput(pedidosDiferentes, outputStatus);
         assertThat(buscaTodosPedidoOutput.hashCode()).isNotEqualTo(outputDiferente.hashCode());

--- a/src/test/java/com/fiap/mspedidoapi/domain/presenters/pedido/GetPedidosPresenterTest.java
+++ b/src/test/java/com/fiap/mspedidoapi/domain/presenters/pedido/GetPedidosPresenterTest.java
@@ -5,8 +5,8 @@ import com.fiap.mspedidoapi.domain.entity.pedido.ProdutoEntity;
 import com.fiap.mspedidoapi.domain.enums.pedido.StatusPagamento;
 import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
 import com.fiap.mspedidoapi.domain.enums.produto.CategoriaEnum;
-import com.fiap.mspedidoapi.domain.output.pedido.BuscaTodosPedidoOutput;
 import com.fiap.mspedidoapi.domain.generic.output.OutputStatus;
+import com.fiap.mspedidoapi.domain.output.pedido.BuscaTodosPedidoOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -32,12 +32,12 @@ public class GetPedidosPresenterTest {
         produto2 = new ProdutoEntity(UUID.randomUUID(), "Produto 2", 1, CategoriaEnum.BEBIDA);
         produto2.setValor(15.0f);
 
-        pedido1 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), StatusPedido.RECEBIDO, StatusPagamento.PAGO, 35.0f);
+        pedido1 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), StatusPedido.RECEBIDO, StatusPagamento.PAGO,20, 35.0f);
         pedido1.setNumeroPedido(12345);
         pedido1.getProdutos().add(produto1);
         pedido1.getProdutos().add(produto2);
 
-        pedido2 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), StatusPedido.EM_PREPARACAO, StatusPagamento.AGUARDANDO_PAGAMENTO, 50.0f);
+        pedido2 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), StatusPedido.EM_PREPARACAO, StatusPagamento.AGUARDANDO_PAGAMENTO,20, 50.0f);
         pedido2.setNumeroPedido(67890);
 
         List<PedidoEntity> pedidos = List.of(pedido1, pedido2);

--- a/src/test/java/com/fiap/mspedidoapi/domain/useCase/pedido/BuscaListaPedidosUseCaseTest.java
+++ b/src/test/java/com/fiap/mspedidoapi/domain/useCase/pedido/BuscaListaPedidosUseCaseTest.java
@@ -4,7 +4,6 @@ import com.fiap.mspedidoapi.domain.entity.pedido.PedidoEntity;
 import com.fiap.mspedidoapi.domain.gateway.pedido.BuscaListaPedidoInterface;
 import com.fiap.mspedidoapi.domain.generic.output.OutputError;
 import com.fiap.mspedidoapi.domain.generic.output.OutputInterface;
-import com.fiap.mspedidoapi.domain.generic.output.OutputStatus;
 import com.fiap.mspedidoapi.domain.output.pedido.BuscaTodosPedidoOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -30,8 +29,8 @@ public class BuscaListaPedidosUseCaseTest {
 
     @Test
     public void deveExecutarBuscaListaPedidosComSucesso() {
-        PedidoEntity pedido1 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 100.0f);
-        PedidoEntity pedido2 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null, 200.0f);
+        PedidoEntity pedido1 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null,20, 100.0f);
+        PedidoEntity pedido2 = new PedidoEntity(UUID.randomUUID(), UUID.randomUUID(), null, null,20, 200.0f);
         List<PedidoEntity> pedidos = List.of(pedido1, pedido2);
 
         when(buscaListaPedidoInterface.findListaPedidos()).thenReturn(pedidos);

--- a/src/test/java/com/fiap/mspedidoapi/domain/useCase/pedido/PedidoProntoUseCaseTest.java
+++ b/src/test/java/com/fiap/mspedidoapi/domain/useCase/pedido/PedidoProntoUseCaseTest.java
@@ -5,7 +5,6 @@ import com.fiap.mspedidoapi.domain.enums.pedido.StatusPedido;
 import com.fiap.mspedidoapi.domain.gateway.pedido.PedidoProntoInterface;
 import com.fiap.mspedidoapi.domain.gateway.producers.PedidoProntoProducerInterface;
 import com.fiap.mspedidoapi.domain.generic.output.OutputError;
-import com.fiap.mspedidoapi.domain.generic.output.OutputStatus;
 import com.fiap.mspedidoapi.domain.output.pedido.PedidoProntoOutput;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -15,7 +14,10 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PedidoProntoUseCaseTest {
 

--- a/src/test/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/PedidoProntoRepositoryTest.java
+++ b/src/test/java/com/fiap/mspedidoapi/infra/adpter/repository/pedido/PedidoProntoRepositoryTest.java
@@ -13,7 +13,10 @@ import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class PedidoProntoRepositoryTest {
 


### PR DESCRIPTION
Adiciona o endpoint `/cozinha/pedido/inicia-preparo`.

Regras de negócio: 
 - O pedido precisa estar com status `RECEBIDO`
 - O `tempoDePreparo` precisa ser positivo

Envia uma mensagem no tópico `pedido`: 

````json
{ 
    "uuid_pedido": "5fad9847-b0f1-4bd2-a3e9-4382f81606cd",
    "status_pedido": "EM_PREPARO",
    "numero_pedido": 1,
    "tempo_preparo": 123 
}
````

